### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/platypus.yml
+++ b/.github/workflows/platypus.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "**/*"
   pull_request:
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/Platypus/security/code-scanning/1](https://github.com/cooljeanius/Platypus/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/platypus.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves existing functionality for checkout/build/test/lint while enforcing least privilege for `GITHUB_TOKEN`.

Change location:

- File: `.github/workflows/platypus.yml`
- Insert `permissions:` between the `on:` trigger block and `jobs:` block.

No imports, methods, or dependencies are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
